### PR TITLE
fix(revoke): go1.18 invalid type

### DIFF
--- a/revoke/revoke_legacy.go
+++ b/revoke/revoke_legacy.go
@@ -75,8 +75,10 @@ func certIsRevokedCRL(cert *x509.Certificate, url string) (revoked, ok bool, err
 		crlLock.Unlock()
 	}
 
-	for _, revoked = range crl.TBSCertList.RevokedCertificates {
-		if cert.SerialNumber.Cmp(revoked.SerialNumber) == 0 {
+	var rc pkix.RevokedCertificate
+
+	for _, rc = range crl.TBSCertList.RevokedCertificates {
+		if cert.SerialNumber.Cmp(rc.SerialNumber) == 0 {
 			return true, true, err
 		}
 	}


### PR DESCRIPTION
This fixes a type error in the go1.18 build.